### PR TITLE
fix: Godot 4.4 typing changes conflict with use of export_enum in sprite_mesh_instance.gd

### DIFF
--- a/demo/addons/sprite_mesh/sprite_mesh_instance.gd
+++ b/demo/addons/sprite_mesh/sprite_mesh_instance.gd
@@ -32,7 +32,7 @@ const GreedyAlgorithm = preload("./scripts/greedy_algorithm.gd")
 ## If [code]true[/code], mesh is flipped vertically.
 @export var flip_v := false: set = set_flip_v
 ## The direction in which the front of the mesh faces.
-@export_enum("X-Axis", "Y-Axis", "Z-Axis") var axis := Vector3.AXIS_Z: set = set_axis
+@export var axis := Vector3.AXIS_Z: set = set_axis
 
 @export_group("Animation")
 ## The number of columns in the sprite sheet.


### PR DESCRIPTION
updated axis export.
replaced `@export_enum` with a simple `@export` to resolve the typing errors encountered with Godot 4.4(rc1)

runtime example:
![image](https://github.com/user-attachments/assets/ad297e12-fb4f-4b0c-a0ac-cc388072888c)
