### PR TITLE
Add custom `editor_delay` export variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Array[ArrayMesh] get_meshes()
 | `Rect2` | [`region_rect`](#rect2-region_rect--rect20-0-0-0) | `Rect2(0, 0, 0, 0)` |
 | `Texture2D` | [`texture`](#texture2d-texture) |  |
 | `float` | [`uv_correction`](#float-uv_correction--00) | `0.0` |
+| `float` | [`editor_delay`](#float-editor_delay--10) | `1.0` |
 | `int` | [`vframes`](#int-vframes--1) | `1` |
 
 ### Methods
@@ -286,6 +287,16 @@ This property aims to fix this problem. When its value increases, the UV mapping
 void set_uv_correction(float uv_correction)
 
 float get_uv_correction()
+```
+
+#### `float editor_delay = 1.0`
+
+The number of seconds before the editor generates the sprite mesh.
+
+```gdscript
+void set_editor_delay(float editor_delay)
+
+float get_editor_delay()
 ```
 
 #### `int vframes = 1`

--- a/demo/addons/sprite_mesh/sprite_mesh_instance.gd
+++ b/demo/addons/sprite_mesh/sprite_mesh_instance.gd
@@ -62,6 +62,8 @@ const GreedyAlgorithm = preload("./scripts/greedy_algorithm.gd")
 ## This property aims to fix this problem. When its value increases, the UV mapping would move
 ## inwards. Be careful, as it would also produce misalignment.
 @export_range(0, 1) var uv_correction := 0.0: set = set_uv_correction
+## The number of seconds before the editor generates the sprite mesh.
+@export var editor_delay := 1.0
 
 @export_group("Generated SpriteMesh")
 ## The result of the algorithm. It would generate automatically in the editor, or after calling
@@ -104,7 +106,7 @@ func _request_update() -> void:
 	_pending_update = true
 
 	if Engine.is_editor_hint():
-		_seconds_left = 1
+		_seconds_left = editor_delay
 
 
 func _generate_sprite_mesh() -> SpriteMesh:


### PR DESCRIPTION
For smaller pixel-art textures (e.g. 32x32) generating the mesh is practically instantaneous, so it can be ideal to reduce the generation delay for the editor.