### PR TITLE
Add on generated signal

### DIFF
--- a/demo/addons/sprite_mesh/sprite_mesh_instance.gd
+++ b/demo/addons/sprite_mesh/sprite_mesh_instance.gd
@@ -7,7 +7,7 @@ extends MeshInstance3D
 
 
 ## Emitted after the sprite mesh is generated.
-signal on_generated_sprite_mesh(sprite_mesh: SpriteMesh);
+signal on_generated_sprite_mesh();
 
 const Quad = preload("./scripts/quad.gd")
 const Frame = preload("./scripts/frame.gd")
@@ -85,7 +85,7 @@ func _process(delta: float):
 	if Engine.is_editor_hint() and _pending_update:
 		if _seconds_left <= 0:
 			_pending_update = false
-			generated_sprite_mesh = _generate_sprite_mesh()
+			_generate_sprite_mesh()
 		else:
 			_seconds_left -= delta
 
@@ -94,7 +94,7 @@ func _process(delta: float):
 func update_sprite_mesh() -> void:
 	if _pending_update:
 		_pending_update = false
-		generated_sprite_mesh = _generate_sprite_mesh()
+		_generate_sprite_mesh()
 
 
 ## Returns the mesh that corresponds to a frame of the animation, represented by its [param index].
@@ -122,7 +122,9 @@ func _generate_sprite_mesh() -> SpriteMesh:
 	sprite_mesh.meshes = _generate_meshes()
 	sprite_mesh.material = _generate_material()
 
-	on_generated_sprite_mesh.emit(sprite_mesh)
+	generated_sprite_mesh = sprite_mesh
+
+	on_generated_sprite_mesh.emit()
 
 	return sprite_mesh
 

--- a/demo/addons/sprite_mesh/sprite_mesh_instance.gd
+++ b/demo/addons/sprite_mesh/sprite_mesh_instance.gd
@@ -6,9 +6,12 @@ extends MeshInstance3D
 ## the sprite. It is inspired by [Sprite3D], so many of its properties behave similarly.
 
 
-const Quad := preload("./scripts/quad.gd")
-const Frame := preload("./scripts/frame.gd")
-const GreedyAlgorithm := preload("./scripts/greedy_algorithm.gd")
+## Emitted after the sprite mesh is generated.
+signal on_generated_sprite_mesh(sprite_mesh: SpriteMesh);
+
+const Quad = preload("./scripts/quad.gd")
+const Frame = preload("./scripts/frame.gd")
+const GreedyAlgorithm = preload("./scripts/greedy_algorithm.gd")
 
 ## [Texture2D] object to draw.
 @export var texture: Texture2D: set = set_texture
@@ -118,6 +121,8 @@ func _generate_sprite_mesh() -> SpriteMesh:
 
 	sprite_mesh.meshes = _generate_meshes()
 	sprite_mesh.material = _generate_material()
+
+	on_generated_sprite_mesh.emit(sprite_mesh)
 
 	return sprite_mesh
 


### PR DESCRIPTION
Supercedes #12.

Example usage:

```cs
GetNode("sprite_mesh_instance").Connect("on_generated_sprite_mesh", Callable.From(CustomizeMaterial));

// ...

public void CustomizeMaterial() {
    StandardMaterial3D standardMaterial = (StandardMaterial3D)SpriteMeshInstance.GetSurfaceOverrideMaterial(0);
    standardMaterial.DiffuseMode = BaseMaterial3D.DiffuseModeEnum.Toon;
}
```